### PR TITLE
HDI-5562 : Stinsen NavigationStack item 받아서 사용하도록 변경

### DIFF
--- a/Sources/NavigationCoordinatable/NavigationStack.swift
+++ b/Sources/NavigationCoordinatable/NavigationStack.swift
@@ -24,17 +24,11 @@ public class NavigationStack<T: NavigationCoordinatable> {
     
     weak var parent: ChildDismissable?
     var poppedTo = PassthroughSubject<Int, Never>()
-    var valueSubject = PassthroughSubject<[NavigationStackItem], Never>()
     let initial: PartialKeyPath<T>
     let initialInput: Any?
     var root: NavigationRoot!
 
-    @Published var value: [NavigationStackItem] {
-        didSet {
-            // NOTE: - Added because Published is an event fired in willSet.
-            valueSubject.send(value)
-        }
-    }
+    @Published var value: [NavigationStackItem]
 
     public init(initial: PartialKeyPath<T>, _ initialInput: Any? = nil) {
         self.value = []


### PR DESCRIPTION
**원인**
- NavigationStack.value의 변경사항이 async하게 전달되면서 이상동작함.

**해결** 
- 값을 넣어두고 꺼내쓰는 방식이 아니라, 전달 받은 값을 사용하도록 수정