### PR TITLE
HDI-12652   [라이브러리] stinsen coordinator 중첩해서 사용하는 경우 화면 이동이 여러번 생기는 현상

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,10 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Stinsen",
     platforms: [
-        .iOS(.v14),
-        .macOS(.v10_15),
-        .tvOS(.v13),
-        .watchOS(.v7)
+        .iOS(.v14)
     ],
     products: [
         .library(name: "Stinsen", targets: ["Stinsen"])

--- a/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
+++ b/Sources/NavigationCoordinatable/NavigationCoordinatable.swift
@@ -333,7 +333,12 @@ public extension NavigationCoordinatable {
     internal func appear(_ int: Int) {        
         self.popTo(int, nil)
     }
-    
+
+    internal func disappear(_ id: Int) {
+        stack.dismissalAction[id]?()
+        stack.dismissalAction[id] = nil
+    }
+
     func popLast(_ action: (() -> ())? = nil) {
         self.popTo(self.stack.value.count - 2, action)
     }

--- a/Sources/NavigationCoordinatable/NavigationCoordinatableView.swift
+++ b/Sources/NavigationCoordinatable/NavigationCoordinatableView.swift
@@ -7,7 +7,7 @@ struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
     var coordinator: T
     private let id: Int
     private let router: NavigationRouter<T>
-    @ObservedObject var presentationHelper: PresentationHelper<T>
+    @StateObject var presentationHelper: PresentationHelper<T>
     @ObservedObject var root: NavigationRoot
     
     var start: AnyView?
@@ -32,23 +32,20 @@ struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
     @ViewBuilder
     var commonView: some View {
         rootView
-            .present(
-                presented: presentationHelper.presented,
-                onAppear: { coordinator.appear(id) },
-                onDismiss: {
-                    coordinator.stack.dismissalAction[id]?()
-                    coordinator.stack.dismissalAction[id] = nil
-                }
-            )
+            .background(UIKitIntrospectionViewController(selector: { $0.parent }) {
+                presentationHelper.setupViewController($0)
+            })
     }
     
     init(id: Int, coordinator: T) {
         self.id = id
         self.coordinator = coordinator
-        self.presentationHelper = PresentationHelper(
-            id: self.id,
-            coordinator: coordinator
-        )
+        self._presentationHelper = StateObject(wrappedValue: {
+            PresentationHelper(
+                id: id,
+                coordinator: coordinator
+            )
+        }())
 
         self.router = NavigationRouter(
             id: id,

--- a/Sources/NavigationCoordinatable/NavigationCoordinatableView.swift
+++ b/Sources/NavigationCoordinatable/NavigationCoordinatableView.swift
@@ -73,26 +73,3 @@ struct NavigationCoordinatableView<T: NavigationCoordinatable>: View {
         }
     }
 }
-
-// MARK: - uikit present
-extension View {
-    func present(presented: Presented?, onAppear: @escaping () -> Void, onDismiss: @escaping () -> Void) -> some View {
-#if os(iOS)
-        background(UIKitIntrospectionViewController(selector: { $0.parent }) { viewController in
-            guard case let .viewController(uiKitPresented) = presented else { return }
-
-            guard let destination = uiKitPresented.viewController else {
-                return
-            }
-            uiKitPresented.presentationType.presented(
-                parent: viewController,
-                content: destination,
-                onAppeared: onAppear,
-                onDissmissed: onDismiss
-            )
-        })
-#else
-        self
-#endif
-    }
-}

--- a/Sources/NavigationCoordinatable/PresentationHelper.swift
+++ b/Sources/NavigationCoordinatable/PresentationHelper.swift
@@ -5,28 +5,32 @@ import SwiftUI
 final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
     private let id: Int
     private var cancellables = Set<AnyCancellable>()
-    
-    @Published var presented: Presented?
-    
+
+    let viewControllerSubject = CurrentValueSubject<WeakRef<UIViewController>, Never>(.empty)
+    let presentedSubject = CurrentValueSubject<Presented?, Never>(nil)
+
+    func setupViewController(_ viewController: UIViewController) {
+        viewControllerSubject.send(WeakRef(value: viewController))
+    }
+
     func setupPresented(coordinator: T, value: [NavigationStackItem]) {
         let nextId = id + 1
-        
         // Only apply updates on last screen in navigation stack
         // This check is important to get the behaviour as using a bool-state in the view that you set
-        guard value.count - 1 == nextId, presented == nil, let value = value[safe: nextId] else { return }
-        
+        guard value.count - 1 == nextId, isEmptyPresented, let value = value[safe: nextId] else { return }
+
         let presentable = value.presentable
-        presented = value.presentationType.makePresented(
+        presentedSubject.send(value.presentationType.makePresented(
             presentable: presentable,
             nextId: nextId,
             coordinator: coordinator
-        )
+        ))
     }
-    
+
     init(id: Int, coordinator: T) {
         self.id = id
         let navigationStack = coordinator.stack
-        
+
         setupPresented(coordinator: coordinator, value: navigationStack.value)
 
         navigationStack
@@ -36,8 +40,9 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
                 self?.setupPresented(coordinator: coordinator, value: items)
             }
             .store(in: &cancellables)
-        
-        navigationStack.poppedTo.filter { int -> Bool in int <= id }
+
+        navigationStack.poppedTo
+            .filter { int -> Bool in int <= id }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] int in
                 // remove any and all presented views if my id is less than or equal to the view being popped to!
@@ -45,12 +50,44 @@ final class PresentationHelper<T: NavigationCoordinatable>: ObservableObject {
 
             }
             .store(in: &cancellables)
+
+        viewControllerSubject
+            .removeDuplicates()
+            .combineLatest(presentedSubject)
+            .sink { [weak self, weak coordinator] in
+                guard let parent = $0.value else { return }
+                $1?.present(
+                    parent: parent,
+                    onAppear: { coordinator?.appear(id) },
+                    onDisappear: { coordinator?.disappear(id) }
+                )
+            }
+            .store(in: &cancellables)
     }
 
     func removePresented() {
-        if case let .viewController(presented) = presented {
+        if case let .viewController(presented) = presentedSubject.value {
             presented.dismiss()
         }
-        presented = nil
+        presentedSubject.send(nil)
+    }
+}
+
+private extension PresentationHelper {
+    var isEmptyPresented: Bool {
+       presentedSubject.value == nil
+   }
+}
+
+private extension Presented {
+    func present(parent: UIViewController, onAppear: @escaping () -> Void, onDisappear: @escaping () -> Void) {
+        guard case let .viewController(uiKitPresented) = self,
+              let destination = uiKitPresented.viewController else { return }
+        uiKitPresented.presentationType.presented(
+            parent: parent,
+            content: destination,
+            onAppeared: onAppear,
+            onDissmissed: onDisappear
+        )
     }
 }

--- a/Sources/NavigationCoordinatable/Presented.swift
+++ b/Sources/NavigationCoordinatable/Presented.swift
@@ -4,24 +4,15 @@ import SwiftUI
 
 public enum Presented {
 
-    case view(ViewPresented)
     case viewController(ViewControllerPresented)
 
-    public var view: AnyView {
-        switch self {
-        case let .view(presented):
-            return presented.view
-        case .viewController:
-            return AnyView(EmptyView())
-        }
-    }
 
     public var type: PresentationType {
         switch self {
-        case let .view(presented):
-            return presented.presentationType
         case let .viewController(presented):
             return presented.presentationType
         }
     }
+    
 }
+

--- a/Sources/NavigationCoordinatable/UIKitPresentationType.swift
+++ b/Sources/NavigationCoordinatable/UIKitPresentationType.swift
@@ -17,16 +17,6 @@ public protocol UIKitPresentationType: PresentationType {
     func dismissed(viewController: UIViewController)
 }
 
-public struct ViewPresented {
-    var view: AnyView
-    var presentationType: PresentationType
-
-    init(view: AnyView, presentationType: PresentationType) {
-        self.view = view
-        self.presentationType = presentationType
-    }
-}
-
 public final class ViewControllerPresented {
 
     init(

--- a/Sources/Utilities/WeakRef.swift
+++ b/Sources/Utilities/WeakRef.swift
@@ -1,10 +1,24 @@
 import Foundation
 
 // see https://swiftrocks.com/weak-dictionary-values-in-swift
-final class WeakRef<T: AnyObject> {
+final class WeakRef<T: AnyObject>: Equatable {
+    static func == (lhs: WeakRef<T>, rhs: WeakRef<T>) -> Bool {
+        lhs.value === rhs.value
+    }
+
     weak var value: T?
     
     init(value: T) {
         self.value = value
+    }
+
+    private init() {
+        self.value = nil
+    }
+}
+
+extension WeakRef {
+    static var empty: WeakRef<T> {
+        WeakRef()
     }
 }


### PR DESCRIPTION
```
 self.presentationHelper = PresentationHelper(
            id: self.id,
            coordinator: coordinator
        )
```
부분이 init가 여러번 호출 되는 상황이 발생
StateObject 로 변경하고 autoclosure 적용

CurrentValueSubject 이용해서 
viewControllerSubject, presentedSubject combineLatest 하는 방향으로 수정